### PR TITLE
feat: Implement Causality Engine (Allen's Interval Algebra) (#12)

### DIFF
--- a/src/coreason_chronos/causality.py
+++ b/src/coreason_chronos/causality.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+from enum import Enum
+
+
+class AllenRelation(str, Enum):
+    """
+    The 13 basic relations of Allen's Interval Algebra.
+    """
+
+    BEFORE = "BEFORE"
+    AFTER = "AFTER"
+    MEETS = "MEETS"
+    MET_BY = "MET_BY"
+    OVERLAPS = "OVERLAPS"
+    OVERLAPPED_BY = "OVERLAPPED_BY"
+    STARTS = "STARTS"
+    STARTED_BY = "STARTED_BY"
+    FINISHES = "FINISHES"
+    FINISHED_BY = "FINISHED_BY"
+    DURING = "DURING"
+    CONTAINS = "CONTAINS"
+    EQUALS = "EQUALS"
+
+
+def get_interval_relation(start_a: datetime, end_a: datetime, start_b: datetime, end_b: datetime) -> AllenRelation:
+    """
+    Determines the Allen Interval Algebra relation between two intervals A and B.
+
+    Args:
+        start_a: Start time of interval A.
+        end_a: End time of interval A.
+        start_b: Start time of interval B.
+        end_b: End time of interval B.
+
+    Returns:
+        The AllenRelation describing the relationship A -> B.
+
+    Raises:
+        ValueError: If any datetime is naive, or if any interval is invalid (start >= end).
+    """
+    # Validation
+    for dt, name in [(start_a, "start_a"), (end_a, "end_a"), (start_b, "start_b"), (end_b, "end_b")]:
+        if dt.tzinfo is None:
+            raise ValueError(f"{name} must be timezone-aware")
+
+    if start_a >= end_a:
+        raise ValueError("Interval A is invalid: start_a must be strictly before end_a (no point events allowed)")
+    if start_b >= end_b:
+        raise ValueError("Interval B is invalid: start_b must be strictly before end_b (no point events allowed)")
+
+    # Logic
+    # 1. BEFORE (A < B): A ends before B starts
+    if end_a < start_b:
+        return AllenRelation.BEFORE
+
+    # 2. AFTER (A > B): A starts after B ends
+    if start_a > end_b:
+        return AllenRelation.AFTER
+
+    # 3. MEETS (A m B): A ends exactly when B starts
+    if end_a == start_b:
+        return AllenRelation.MEETS
+
+    # 4. MET_BY (A mi B): A starts exactly when B ends
+    if start_a == end_b:
+        return AllenRelation.MET_BY
+
+    # 5. OVERLAPS (A o B): A starts before B, A ends after B starts but before B ends
+    if start_a < start_b and start_b < end_a < end_b:
+        return AllenRelation.OVERLAPS
+
+    # 6. OVERLAPPED_BY (A oi B): B starts before A, B ends after A starts but before A ends
+    if start_b < start_a and start_a < end_b < end_a:
+        return AllenRelation.OVERLAPPED_BY
+
+    # 7. STARTS (A s B): A and B start together, A ends before B
+    if start_a == start_b and end_a < end_b:
+        return AllenRelation.STARTS
+
+    # 8. STARTED_BY (A si B): A and B start together, A ends after B
+    if start_a == start_b and end_a > end_b:
+        return AllenRelation.STARTED_BY
+
+    # 9. FINISHES (A f B): A ends with B, A starts after B starts
+    if end_a == end_b and start_a > start_b:
+        return AllenRelation.FINISHES
+
+    # 10. FINISHED_BY (A fi B): A ends with B, A starts before B starts
+    if end_a == end_b and start_a < start_b:
+        return AllenRelation.FINISHED_BY
+
+    # 11. DURING (A d B): A starts after B starts and ends before B ends
+    if start_a > start_b and end_a < end_b:
+        return AllenRelation.DURING
+
+    # 12. CONTAINS (A di B): A starts before B starts and ends after B ends
+    if start_a < start_b and end_a > end_b:
+        return AllenRelation.CONTAINS
+
+    # 13. EQUALS (A = B): A and B start and end together
+    if start_a == start_b and end_a == end_b:
+        return AllenRelation.EQUALS
+
+    # Should be unreachable if logic is complete, but let's see.
+    # Are there any other cases?
+    # Logic covers:
+    # Disjoint: Before, After
+    # Touching: Meets, Met By
+    # Overlapping boundaries: Overlaps, Overlapped By
+    # Matching Start: Starts, Started By, Equals
+    # Matching End: Finishes, Finished By, Equals
+    # Nested: During, Contains
+
+    # It seems complete.
+    raise ValueError("Unable to determine relation. This code path should be unreachable.")  # pragma: no cover

--- a/tests/test_causality.py
+++ b/tests/test_causality.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from coreason_chronos.causality import AllenRelation, get_interval_relation
+
+
+# Helper for creating UTC datetimes
+def dt(hour: int, minute: int = 0) -> datetime:
+    return datetime(2024, 1, 1, hour, minute, tzinfo=timezone.utc)
+
+
+def test_before() -> None:
+    # A: 10:00-11:00, B: 12:00-13:00
+    r = get_interval_relation(dt(10), dt(11), dt(12), dt(13))
+    assert r == AllenRelation.BEFORE
+
+
+def test_after() -> None:
+    # A: 12:00-13:00, B: 10:00-11:00
+    r = get_interval_relation(dt(12), dt(13), dt(10), dt(11))
+    assert r == AllenRelation.AFTER
+
+
+def test_meets() -> None:
+    # A: 10:00-11:00, B: 11:00-12:00
+    r = get_interval_relation(dt(10), dt(11), dt(11), dt(12))
+    assert r == AllenRelation.MEETS
+
+
+def test_met_by() -> None:
+    # A: 11:00-12:00, B: 10:00-11:00
+    r = get_interval_relation(dt(11), dt(12), dt(10), dt(11))
+    assert r == AllenRelation.MET_BY
+
+
+def test_overlaps() -> None:
+    # A: 10:00-12:00, B: 11:00-13:00
+    r = get_interval_relation(dt(10), dt(12), dt(11), dt(13))
+    assert r == AllenRelation.OVERLAPS
+
+
+def test_overlapped_by() -> None:
+    # A: 11:00-13:00, B: 10:00-12:00
+    r = get_interval_relation(dt(11), dt(13), dt(10), dt(12))
+    assert r == AllenRelation.OVERLAPPED_BY
+
+
+def test_starts() -> None:
+    # A: 10:00-11:00, B: 10:00-12:00
+    r = get_interval_relation(dt(10), dt(11), dt(10), dt(12))
+    assert r == AllenRelation.STARTS
+
+
+def test_started_by() -> None:
+    # A: 10:00-12:00, B: 10:00-11:00
+    r = get_interval_relation(dt(10), dt(12), dt(10), dt(11))
+    assert r == AllenRelation.STARTED_BY
+
+
+def test_finishes() -> None:
+    # A: 11:00-12:00, B: 10:00-12:00
+    r = get_interval_relation(dt(11), dt(12), dt(10), dt(12))
+    assert r == AllenRelation.FINISHES
+
+
+def test_finished_by() -> None:
+    # A: 10:00-12:00, B: 11:00-12:00
+    r = get_interval_relation(dt(10), dt(12), dt(11), dt(12))
+    assert r == AllenRelation.FINISHED_BY
+
+
+def test_during() -> None:
+    # A: 11:00-12:00, B: 10:00-13:00
+    r = get_interval_relation(dt(11), dt(12), dt(10), dt(13))
+    assert r == AllenRelation.DURING
+
+
+def test_contains() -> None:
+    # A: 10:00-13:00, B: 11:00-12:00
+    r = get_interval_relation(dt(10), dt(13), dt(11), dt(12))
+    assert r == AllenRelation.CONTAINS
+
+
+def test_equals() -> None:
+    # A: 10:00-11:00, B: 10:00-11:00
+    r = get_interval_relation(dt(10), dt(11), dt(10), dt(11))
+    assert r == AllenRelation.EQUALS
+
+
+def test_invalid_naive_datetime() -> None:
+    naive = datetime(2024, 1, 1, 10, 0)
+    aware = dt(10)
+    with pytest.raises(ValueError, match="must be timezone-aware"):
+        get_interval_relation(naive, aware, aware, aware)
+
+
+def test_invalid_point_event_A() -> None:
+    # start == end
+    with pytest.raises(ValueError, match="Interval A is invalid"):
+        get_interval_relation(dt(10), dt(10), dt(10), dt(11))
+
+
+def test_invalid_inverted_event_A() -> None:
+    # start > end
+    with pytest.raises(ValueError, match="Interval A is invalid"):
+        get_interval_relation(dt(11), dt(10), dt(10), dt(11))
+
+
+def test_invalid_point_event_B() -> None:
+    # start == end
+    with pytest.raises(ValueError, match="Interval B is invalid"):
+        get_interval_relation(dt(10), dt(11), dt(10), dt(10))
+
+
+def test_timezone_conversion() -> None:
+    # Compare UTC with UTC+1
+    # 10:00 UTC
+    start_a = dt(10)
+    end_a = dt(11)
+
+    # 10:00 UTC is 11:00 UTC+1
+    tz_plus_1 = timezone(timedelta(hours=1))
+    start_b = datetime(2024, 1, 1, 11, 0, tzinfo=tz_plus_1)
+    # 11:00 UTC is 12:00 UTC+1
+    end_b = datetime(2024, 1, 1, 12, 0, tzinfo=tz_plus_1)
+
+    # Should be EQUALS because they represent the same absolute time
+    r = get_interval_relation(start_a, end_a, start_b, end_b)
+    assert r == AllenRelation.EQUALS


### PR DESCRIPTION
* feat: Implement Causality Engine with Allen's Interval Algebra

- Introduced `src/coreason_chronos/causality.py` containing the `AllenRelation` enum and `get_interval_relation` logic.
- Implemented strict validations for timezone awareness and interval consistency (start < end).
- Added comprehensive unit tests in `tests/test_causality.py` covering all 13 Allen relations and edge cases.
- Achieved 100% test coverage for the new module.
- Adhered to strict coding standards with full typing and no external dependencies for this unit.