### PR TITLE
Implement fuzzy anchor resolution in TimelineExtractor (#18)

### DIFF
--- a/tests/test_timeline_extractor_complex_fuzzy.py
+++ b/tests/test_timeline_extractor_complex_fuzzy.py
@@ -1,0 +1,90 @@
+from datetime import datetime, timezone
+
+from coreason_chronos.timeline_extractor import TimelineExtractor
+
+
+def test_ambiguous_fuzzy_match_prioritizes_score() -> None:
+    """
+    Test that a high-score match (exact words) is preferred over a low-score match (partial words),
+    even if the low-score match is closer in the text.
+
+    Scenario:
+    Event A: "Second Infusion" (Target, 100% match, Farther)
+    Event B: "Third Infusion" (Distractor, 50% match, Closer)
+    Anchor: "the second infusion"
+    """
+    # Layout: [Second Infusion] ... [Third Infusion] ... [Anchor "after second infusion"]
+    # Distance: Anchor -> Third is smaller than Anchor -> Second.
+    # Logic must pick Second because "second" matches "second", but "third" does not.
+
+    text = (
+        "History: Second Infusion on Jan 10. Current: Third Infusion on Jan 20. "
+        "Reaction 2 days after the second infusion."
+    )
+    # Use ref_date in Feb so Jan dates are treated as current year (2024)
+    ref_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
+
+    extractor = TimelineExtractor()
+    events = extractor.extract_events(text, ref_date)
+
+    # Events:
+    # 1. Jan 10 (Second)
+    # 2. Jan 20 (Third)
+    # 3. Reaction. Should be Jan 10 + 2 = Jan 12.
+
+    assert len(events) >= 3
+
+    # Identify the reaction event robustly using source_snippet
+    reaction = next(e for e in events if "after the second infusion" in e.source_snippet)
+
+    # Expectation: Jan 12
+    assert reaction.timestamp == datetime(2024, 1, 12, tzinfo=timezone.utc)
+
+
+def test_chained_fuzzy_events() -> None:
+    """
+    Test chained dependencies with fuzzy matching.
+    Event A: "Surgery on Jan 1"
+    Event B: "Discharge 3 days after surgery" (Fuzzy link to A)
+    Event C: "Follow-up 1 week after discharge" (Fuzzy link to B)
+    """
+    text = "Surgery on Jan 1. Discharge 3 days after surgery. Follow-up 1 week after discharge."
+    ref_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
+
+    extractor = TimelineExtractor()
+    events = extractor.extract_events(text, ref_date)
+
+    # 1. Surgery: Jan 1
+    # 2. Discharge: Jan 4
+    # 3. Follow-up: Jan 11
+
+    events.sort(key=lambda x: x.timestamp)
+    assert len(events) == 3
+
+    surgery = events[0]
+    discharge = events[1]
+    followup = events[2]
+
+    assert surgery.timestamp == datetime(2024, 1, 1, tzinfo=timezone.utc)
+    assert discharge.timestamp == datetime(2024, 1, 4, tzinfo=timezone.utc)
+    assert followup.timestamp == datetime(2024, 1, 11, tzinfo=timezone.utc)
+
+
+def test_fuzzy_match_far_away() -> None:
+    """
+    Test fuzzy match where the anchor is far away from the event, ensuring no context overlap.
+    """
+    # Event "Second Infusion" is at start.
+    # Anchor "after second infusion" is > 50 chars away.
+    padding = " " * 100
+    text = f"Second Infusion on Jan 10.{padding}Reaction 2 days after the second infusion."
+    ref_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
+
+    extractor = TimelineExtractor()
+    events = extractor.extract_events(text, ref_date)
+
+    assert len(events) >= 2
+    reaction = next(e for e in events if "after the second infusion" in e.source_snippet)
+
+    # Should resolve to Jan 12
+    assert reaction.timestamp == datetime(2024, 1, 12, tzinfo=timezone.utc)

--- a/tests/test_timeline_extractor_fuzzy.py
+++ b/tests/test_timeline_extractor_fuzzy.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+
+from coreason_chronos.timeline_extractor import TimelineExtractor
+
+
+def test_story_a_fuzzy_match() -> None:
+    """
+    Test Story A: "Patient felt nausea 2 days after the second infusion."
+    Event: "Second Infusion Date: 2024-06-10"
+
+    The anchor "the second infusion" does not appear verbatim in the reference event text.
+    It requires matching "the second infusion" to "Second Infusion Date".
+    """
+    text = "Clinical Notes. Second Infusion Date: 2024-06-10. Patient felt nausea 2 days after the second infusion."
+    ref_date = datetime(2024, 6, 20, tzinfo=timezone.utc)  # Ref date after events
+
+    extractor = TimelineExtractor()
+    events = extractor.extract_events(text, ref_date)
+
+    # We expect 2 events:
+    # 1. 2024-06-10 (The infusion)
+    # 2. 2024-06-12 (The nausea, 2 days after)
+
+    assert len(events) >= 2
+
+    # Sort by time
+    events.sort(key=lambda x: x.timestamp)
+
+    infusion = events[0]
+    nausea = events[1]
+
+    assert infusion.timestamp == datetime(2024, 6, 10, tzinfo=timezone.utc)
+    assert nausea.timestamp == datetime(2024, 6, 12, tzinfo=timezone.utc)
+    assert (
+        "nausea" in nausea.description or "nausea" in nausea.source_snippet or "derived" in nausea.description.lower()
+    )
+
+
+def test_fuzzy_match_anchor_before_event() -> None:
+    """
+    Test where the anchor appears before the event definition in the text.
+    "Symptoms started 2 days before surgery. Surgery was on Jan 5."
+    """
+    text = "Symptoms started 2 days before surgery. Surgery was on Jan 5."
+    # Use ref_date after Jan 5 so Jan 5 is considered 'past' (2024)
+    ref_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
+
+    extractor = TimelineExtractor()
+    events = extractor.extract_events(text, ref_date)
+
+    assert len(events) >= 2
+    events.sort(key=lambda x: x.timestamp)
+
+    symptoms = events[0]
+    surgery = events[1]
+
+    assert surgery.timestamp == datetime(2024, 1, 5, tzinfo=timezone.utc)
+    assert symptoms.timestamp == datetime(2024, 1, 3, tzinfo=timezone.utc)


### PR DESCRIPTION
* feat: Implement fuzzy anchor resolution in TimelineExtractor

- Added `_is_semantic_match` to `TimelineExtractor` to match anchor phrases against event descriptions using token overlap.
- Updated `extract_events` to search for matches in `resolved_events_meta` using the new fuzzy matcher.
- Added `tests/test_timeline_extractor_fuzzy.py` to verify "Story A" and other fuzzy matching scenarios.
- Achieved 100% test coverage and passed all pre-commit hooks.