### PR TITLE
Enhance Forecast CLI with Visualization and Quantization Support (#35)

### DIFF
--- a/src/coreason_chronos/main.py
+++ b/src/coreason_chronos/main.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import click
 from dateparser import parse
+from pydantic import ValidationError
 
 from coreason_chronos.agent import ChronosTimekeeper
 from coreason_chronos.schemas import TemporalEvent
@@ -68,7 +69,16 @@ def extract(input_text: Optional[str], file: Optional[str], ref_date: str) -> No
 @click.option("--steps", "-s", default=12, help="Number of steps to forecast.")
 @click.option("--confidence", "-c", default=0.9, help="Confidence level (0.0 - 1.0).")
 @click.option("--model", "-m", default="amazon/chronos-t5-tiny", help="HuggingFace model ID.")
-def forecast(history_str: str, steps: int, confidence: float, model: str) -> None:
+@click.option("--quantization", "-q", help="Quantization mode (e.g. 'int8').")
+@click.option("--plot-output", "-p", type=click.Path(writable=True), help="Path to save the forecast plot.")
+def forecast(
+    history_str: str,
+    steps: int,
+    confidence: float,
+    model: str,
+    quantization: Optional[str],
+    plot_output: Optional[str],
+) -> None:
     """
     Forecast future values based on history.
     HISTORY should be a comma-separated list of numbers.
@@ -79,10 +89,31 @@ def forecast(history_str: str, steps: int, confidence: float, model: str) -> Non
         click.echo("Error: History must be a comma-separated list of numbers.", err=True)
         sys.exit(1)
 
-    agent = ChronosTimekeeper(model_name=model, device="cpu")
-    result = agent.forecast_series(history, steps, confidence)
+    try:
+        agent = ChronosTimekeeper(model_name=model, device="cpu", quantization=quantization)
+        result = agent.forecast_series(history, steps, confidence)
+    except (ValueError, ValidationError) as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
 
     click.echo(json.dumps(result.model_dump(mode="json"), indent=2))
+
+    if plot_output:
+        try:
+            import matplotlib.pyplot as plt
+
+            from coreason_chronos.schemas import ForecastRequest
+            from coreason_chronos.visualizer import plot_forecast
+
+            # Reconstruct request object since Agent consumes it internally
+            req = ForecastRequest(history=history, prediction_length=steps, confidence_level=confidence)
+            fig = plot_forecast(req, result, title="Chronos Forecast")
+            fig.savefig(plot_output)
+            plt.close(fig)
+            logger.info(f"Forecast plot saved to {plot_output}")
+        except OSError as e:
+            click.echo(f"Error: Failed to save plot. {e}", err=True)
+            sys.exit(1)
 
 
 @cli.command()

--- a/tests/test_main_edge_cases.py
+++ b/tests/test_main_edge_cases.py
@@ -1,0 +1,123 @@
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from coreason_chronos.main import cli
+
+
+def test_forecast_invalid_quantization() -> None:
+    """
+    Test that invalid quantization mode is handled gracefully.
+    """
+    with patch("coreason_chronos.agent.ChronosForecaster") as MockForecaster:
+        # Mock initialization to raise ValueError
+        MockForecaster.side_effect = ValueError("Unsupported quantization mode: invalid")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["forecast", "10,20", "--quantization", "invalid"])
+
+        assert result.exit_code != 0
+        assert "Error: Unsupported quantization mode: invalid" in result.output
+
+
+def test_forecast_plot_file_error() -> None:
+    """
+    Test that file write errors during plotting are handled gracefully.
+    """
+    with patch("coreason_chronos.agent.ChronosForecaster") as MockForecaster:
+        mock_instance = MockForecaster.return_value
+        mock_instance.forecast.return_value = MagicMock(
+            median=[110.0],
+            lower_bound=[100.0],
+            upper_bound=[120.0],
+            confidence_level=0.9,
+            model_dump=lambda **kwargs: {},
+        )
+
+        with patch("coreason_chronos.visualizer.plot_forecast") as mock_plot:
+            mock_fig = MagicMock()
+            mock_plot.return_value = mock_fig
+            # Simulate OSError when saving (e.g. permission denied or directory not found)
+            mock_fig.savefig.side_effect = OSError("Permission denied")
+
+            with patch("matplotlib.pyplot.close"):
+                runner = CliRunner()
+                # Providing a path that would cause error if not mocked, but mock handles it
+                result = runner.invoke(cli, ["forecast", "10,20", "--plot-output", "/invalid/path.png"])
+
+                # Should fail gracefully
+                assert result.exit_code != 0
+                assert "Error: Failed to save plot" in result.output
+                assert "Permission denied" in result.output
+
+
+def test_forecast_invalid_steps() -> None:
+    """
+    Test that invalid prediction length (steps) is handled gracefully.
+    """
+    # We patch ChronosForecaster so Agent initialization succeeds.
+    with patch("coreason_chronos.agent.ChronosForecaster"):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["forecast", "10,20", "--steps", "-5"])
+
+        # It should exit with non-zero
+        assert result.exit_code != 0
+        # The output should contain the pydantic error details
+        assert "prediction_length must be positive" in result.output
+
+
+def test_forecast_complex_success() -> None:
+    """
+    Complex scenario: All options enabled.
+    """
+    with patch("coreason_chronos.agent.ChronosForecaster") as MockForecaster:
+        mock_instance = MockForecaster.return_value
+        mock_instance.forecast.return_value = MagicMock(
+            median=[110.0, 112.0],
+            lower_bound=[100.0, 102.0],
+            upper_bound=[120.0, 122.0],
+            confidence_level=0.95,
+            model_dump=lambda **kwargs: {"median": [110.0, 112.0], "confidence_level": 0.95},
+        )
+
+        with patch("coreason_chronos.visualizer.plot_forecast") as mock_plot:
+            mock_fig = MagicMock()
+            mock_plot.return_value = mock_fig
+
+            with patch("matplotlib.pyplot.close") as mock_close:
+                runner = CliRunner()
+                with runner.isolated_filesystem():
+                    # Invoke with all options
+                    result = runner.invoke(
+                        cli,
+                        [
+                            "forecast",
+                            "10,20,30,40,50",
+                            "--steps",
+                            "2",
+                            "--confidence",
+                            "0.95",
+                            "--quantization",
+                            "int8",
+                            "--model",
+                            "test/model",
+                            "--plot-output",
+                            "out.png",
+                        ],
+                    )
+
+                    assert result.exit_code == 0
+
+                    # Verify initialization with all params
+                    MockForecaster.assert_called_with(model_name="test/model", device="cpu", quantization="int8")
+
+                    # Verify forecast call
+                    args, _ = mock_instance.forecast.call_args
+                    req = args[0]
+                    assert req.history == [10.0, 20.0, 30.0, 40.0, 50.0]
+                    assert req.prediction_length == 2
+                    assert req.confidence_level == 0.95
+
+                    # Verify plot saved
+                    mock_fig.savefig.assert_called_once_with("out.png")
+                    mock_close.assert_called_once()


### PR DESCRIPTION
* feat: enhance forecast CLI with quantization and plotting support

- Updated `forecast` command in `main.py` to accept `--quantization` and `--plot-output`.
- Integrated `visualizer.plot_forecast` to save forecast plots when requested.
- Passed `quantization` argument to `ChronosTimekeeper` and `ChronosForecaster`.
- Added comprehensive tests for new CLI options in `tests/test_main.py`.
- Verified 100% test coverage and compliance with strict pre-commit checks.

* feat: add CLI forecast edge case handling and robust tests

- Enhanced `forecast` command in `main.py` with `try...except` blocks for `ValueError`, `ValidationError`, and `OSError`.
- Added `tests/test_main_edge_cases.py` verifying graceful failure for invalid quantization, plot file errors, and invalid steps.
- Ensured graceful error messages are printed to stderr without tracebacks.
- Verified 100% test coverage and compliance with strict pre-commit checks.